### PR TITLE
Replaced google's common Optionals with java.util.Optional

### DIFF
--- a/src/main/java/nl/rutgerkok/blocklocker/BlockLockerAPI.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/BlockLockerAPI.java
@@ -1,11 +1,8 @@
 package nl.rutgerkok.blocklocker;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
-
-import nl.rutgerkok.blocklocker.profile.PlayerProfile;
-import nl.rutgerkok.blocklocker.profile.Profile;
-import nl.rutgerkok.blocklocker.protection.Protection;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -13,7 +10,9 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import com.google.common.base.Optional;
+import nl.rutgerkok.blocklocker.profile.PlayerProfile;
+import nl.rutgerkok.blocklocker.profile.Profile;
+import nl.rutgerkok.blocklocker.protection.Protection;
 
 /**
  * This class is intended as an easy way for other plugin developers to hook
@@ -36,10 +35,10 @@ public final class BlockLockerAPI {
     public static Optional<OfflinePlayer> getOwner(Block block) {
         Optional<Protection> protection = getPlugin().getProtectionFinder().findProtection(block);
         if (!protection.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
-        Profile owner = protection.get().getOwner().orNull();
+        Profile owner = protection.get().getOwner().orElse(null);
         if (owner instanceof PlayerProfile) {
             Optional<UUID> uuid = ((PlayerProfile) owner).getUniqueId();
             if (uuid.isPresent()) {
@@ -48,10 +47,10 @@ public final class BlockLockerAPI {
 
             // No uuid looked up yet
             getPlugin().getProtectionUpdater().update(protection.get(), false);
-            return Optional.fromNullable(Bukkit.getOfflinePlayer(owner.getDisplayName()));
+            return Optional.ofNullable(Bukkit.getOfflinePlayer(owner.getDisplayName()));
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
     /**
@@ -67,7 +66,7 @@ public final class BlockLockerAPI {
     public static Optional<String> getOwnerDisplayName(Block block) {
         Optional<Protection> protection = getPlugin().getProtectionFinder().findProtection(block);
         if (!protection.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
         return Optional.of(protection.get().getOwnerDisplayName());
     }

--- a/src/main/java/nl/rutgerkok/blocklocker/ChestSettings.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/ChestSettings.java
@@ -2,11 +2,10 @@ package nl.rutgerkok.blocklocker;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.bukkit.Material;
-
-import com.google.common.base.Optional;
 
 /**
  * Represents all settings of the plugin.

--- a/src/main/java/nl/rutgerkok/blocklocker/ProfileFactory.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/ProfileFactory.java
@@ -1,13 +1,12 @@
 package nl.rutgerkok.blocklocker;
 
+import java.util.Optional;
 import java.util.UUID;
-
-import nl.rutgerkok.blocklocker.profile.PlayerProfile;
-import nl.rutgerkok.blocklocker.profile.Profile;
 
 import org.bukkit.entity.Player;
 
-import com.google.common.base.Optional;
+import nl.rutgerkok.blocklocker.profile.PlayerProfile;
+import nl.rutgerkok.blocklocker.profile.Profile;
 
 public interface ProfileFactory {
 

--- a/src/main/java/nl/rutgerkok/blocklocker/ProtectionFinder.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/ProtectionFinder.java
@@ -1,9 +1,9 @@
 package nl.rutgerkok.blocklocker;
 
+import java.util.Optional;
+
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
-
-import com.google.common.base.Optional;
 
 import nl.rutgerkok.blocklocker.profile.Profile;
 import nl.rutgerkok.blocklocker.protection.Protection;

--- a/src/main/java/nl/rutgerkok/blocklocker/SignParser.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/SignParser.java
@@ -1,10 +1,10 @@
 package nl.rutgerkok.blocklocker;
 
+import java.util.Optional;
+
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.event.block.SignChangeEvent;
-
-import com.google.common.base.Optional;
 
 /**
  * Parses a single sign. It essentially converts between {@link Sign} and

--- a/src/main/java/nl/rutgerkok/blocklocker/SignSelector.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/SignSelector.java
@@ -1,9 +1,9 @@
 package nl.rutgerkok.blocklocker;
 
+import java.util.Optional;
+
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
-
-import com.google.common.base.Optional;
 
 /**
  * Holds the signs the players have selected.

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/ChestSettingsImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/ChestSettingsImpl.java
@@ -4,7 +4,10 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
+
+import org.bukkit.Material;
 
 import nl.rutgerkok.blocklocker.AttackType;
 import nl.rutgerkok.blocklocker.ChestSettings;
@@ -12,10 +15,6 @@ import nl.rutgerkok.blocklocker.ProtectionType;
 import nl.rutgerkok.blocklocker.SignType;
 import nl.rutgerkok.blocklocker.Translator;
 import nl.rutgerkok.blocklocker.Translator.Translation;
-
-import org.bukkit.Material;
-
-import com.google.common.base.Optional;
 
 class ChestSettingsImpl implements ChestSettings {
 
@@ -58,7 +57,7 @@ class ChestSettingsImpl implements ChestSettings {
     public Optional<Date> getChestExpireDate() {
         int days = config.getAutoExpireDays();
         if (days <= 0) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         // Calculate the cutoff date
@@ -94,7 +93,7 @@ class ChestSettingsImpl implements ChestSettings {
                 return Optional.of(type);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/ProtectionFinderImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/ProtectionFinderImpl.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -12,7 +13,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import nl.rutgerkok.blocklocker.ChestSettings;
@@ -47,12 +47,12 @@ class ProtectionFinderImpl implements ProtectionFinder {
     public Optional<Protection> findExistingProtectionForNewSign(Block signBlock) {
         BlockState blockState = signBlock.getState();
         if (!(blockState instanceof Sign)) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         Optional<Block> protectionBlock = this.findProtectableForSign(signBlock);
         if (!protectionBlock.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         return findProtectionForBlock(protectionBlock.get(), SearchMode.NO_SUPPORTING_BLOCKS);
@@ -110,7 +110,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
             }
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override
@@ -158,7 +158,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
         }
 
         // Failed
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private Optional<Protection> findProtectionForExistingSign(Block sign) {
@@ -166,7 +166,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
         Optional<ProtectionSign> parsed = blockFinder.getSignParser().parseSign(sign);
         if (!parsed.isPresent()) {
             // Not actually a protection sign, so no protection
-            return Optional.absent();
+            return Optional.empty();
         }
 
         Optional<Block> protectionBlock = findProtectableForSign(sign);
@@ -174,13 +174,13 @@ class ProtectionFinderImpl implements ProtectionFinder {
             return findProtectionForProtectionBlock(protectionBlock.get(), parsed.get());
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private Optional<Protection> findProtectionForProtectionBlock(Block protectionBlock) {
         Optional<ProtectionType> protectionType = settings.getProtectionType(protectionBlock.getType());
         if (!protectionType.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         // We don't know yet if signs are attached, so we have to check for that
@@ -191,7 +191,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
                 List<Block> blocks = blockFinder.findContainerNeighbors(protectionBlock);
                 Collection<ProtectionSign> signs = blockFinder.findAttachedSigns(blocks);
                 if (signs.isEmpty()) {
-                    return Optional.absent();
+                    return Optional.empty();
                 }
                 return Optional.of(ContainerProtectionImpl.fromBlocksWithSigns(
                         signs, blocks, blockFinder));
@@ -199,7 +199,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
                 CompleteDoor door = new CompleteDoor(protectionBlock);
                 Collection<ProtectionSign> doorSigns = blockFinder.findAttachedSigns(door.getBlocksForSigns());
                 if (doorSigns.isEmpty()) {
-                    return Optional.absent();
+                    return Optional.empty();
                 }
                 return Optional.of(DoorProtectionImpl.fromDoorWithSigns(
                         doorSigns, blockFinder, door));
@@ -207,7 +207,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
                 Collection<ProtectionSign> trapDoorSigns = blockFinder.findAttachedSigns(
                         Arrays.asList(protectionBlock, blockFinder.findSupportingBlock(protectionBlock)));
                 if (trapDoorSigns.isEmpty()) {
-                    return Optional.absent();
+                    return Optional.empty();
                 }
                 return Optional.of(AttachedProtectionImpl.fromBlockWithSigns(
                         trapDoorSigns, blockFinder, protectionBlock));
@@ -233,7 +233,7 @@ class ProtectionFinderImpl implements ProtectionFinder {
     private Optional<Protection> findProtectionForProtectionBlock(Block protectionBlock, ProtectionSign sign) {
         Optional<ProtectionType> protectionType = settings.getProtectionType(protectionBlock.getType());
         if (!protectionType.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         switch (protectionType.get()) {

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/SignParserImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/SignParserImpl.java
@@ -2,15 +2,7 @@ package nl.rutgerkok.blocklocker.impl;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import nl.rutgerkok.blocklocker.ChestSettings;
-import nl.rutgerkok.blocklocker.ProtectionSign;
-import nl.rutgerkok.blocklocker.SignParser;
-import nl.rutgerkok.blocklocker.SignType;
-import nl.rutgerkok.blocklocker.impl.nms.ServerSpecific;
-import nl.rutgerkok.blocklocker.impl.nms.ServerSpecific.JsonSign;
-import nl.rutgerkok.blocklocker.impl.profile.ProfileFactoryImpl;
-import nl.rutgerkok.blocklocker.profile.Profile;
+import java.util.Optional;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -21,7 +13,14 @@ import org.bukkit.event.block.SignChangeEvent;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
-import com.google.common.base.Optional;
+import nl.rutgerkok.blocklocker.ChestSettings;
+import nl.rutgerkok.blocklocker.ProtectionSign;
+import nl.rutgerkok.blocklocker.SignParser;
+import nl.rutgerkok.blocklocker.SignType;
+import nl.rutgerkok.blocklocker.impl.nms.ServerSpecific;
+import nl.rutgerkok.blocklocker.impl.nms.ServerSpecific.JsonSign;
+import nl.rutgerkok.blocklocker.impl.profile.ProfileFactoryImpl;
+import nl.rutgerkok.blocklocker.profile.Profile;
 
 /**
  * Reads a single sign for profiles. Doesn't verify the sign header, the first
@@ -44,12 +43,12 @@ class SignParserImpl implements SignParser {
     @Override
     public Optional<SignType> getSignType(Sign sign) {
         String header = sign.getLine(0);
-        return Optional.fromNullable(getSignTypeOrNull(header));
+        return Optional.ofNullable(getSignTypeOrNull(header));
     }
 
     @Override
     public Optional<SignType> getSignType(SignChangeEvent event) {
-        return Optional.fromNullable(getSignTypeOrNull(event.getLine(0)));
+        return Optional.ofNullable(getSignTypeOrNull(event.getLine(0)));
     }
 
     private SignType getSignTypeOrNull(String header) {
@@ -81,7 +80,7 @@ class SignParserImpl implements SignParser {
     private Optional<ProtectionSign> parseAdvancedSign(Location location, String header, Iterable<JSONObject> list) {
         SignType signType = getSignTypeOrNull(header);
         if (signType == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         List<Profile> profiles = new ArrayList<Profile>();
@@ -124,7 +123,7 @@ class SignParserImpl implements SignParser {
     private Optional<ProtectionSign> parseSimpleSign(Location location, String[] lines) {
         SignType signType = getSignTypeOrNull(lines[0]);
         if (signType == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         List<Profile> profiles = new ArrayList<Profile>();

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/SignSelectorImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/SignSelectorImpl.java
@@ -1,8 +1,7 @@
 package nl.rutgerkok.blocklocker.impl;
 
 import java.util.List;
-
-import nl.rutgerkok.blocklocker.SignSelector;
+import java.util.Optional;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -16,7 +15,7 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.BlockVector;
 
-import com.google.common.base.Optional;
+import nl.rutgerkok.blocklocker.SignSelector;
 
 /**
  * Selected signs are stored as metadata on a player. The values won't get
@@ -54,20 +53,20 @@ final class SignSelectorImpl implements SignSelector {
         List<MetadataValue> signTime = player.getMetadata(SIGN_TIME);
 
         if (signVector.isEmpty() || signWorld.isEmpty() || signTime.isEmpty()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         BlockVector vector = (BlockVector) signVector.get(0).value();
         World world = Bukkit.getWorld(signWorld.get(0).asString());
         if (world == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         // Check for expiration
         long createdMillis = signTime.get(0).asLong();
         if (isExpired(createdMillis)) {
             clearValues(player);
-            return Optional.absent();
+            return Optional.empty();
         }
 
         Location signLocation = vector.toLocation(world);
@@ -77,7 +76,7 @@ final class SignSelectorImpl implements SignSelector {
             return Optional.of((Sign) signState);
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private boolean isExpired(long time) {

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/blockfinder/BlockFinder.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/blockfinder/BlockFinder.java
@@ -3,6 +3,7 @@ package nl.rutgerkok.blocklocker.impl.blockfinder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -15,7 +16,6 @@ import org.bukkit.block.data.type.Chest.Type;
 import org.bukkit.block.data.type.Gate;
 import org.bukkit.block.data.type.WallSign;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionMissingIds.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionMissingIds.java
@@ -1,9 +1,9 @@
 package nl.rutgerkok.blocklocker.impl.converter;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import nl.rutgerkok.blocklocker.profile.PlayerProfile;
@@ -44,7 +44,7 @@ final class ProtectionMissingIds {
         if (missingIds) {
             return Optional.of(new ProtectionMissingIds(protection, namesMissingUniqueIds));
         } else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionNameUpdater.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionNameUpdater.java
@@ -2,7 +2,13 @@ package nl.rutgerkok.blocklocker.impl.converter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.google.common.base.Preconditions;
 
 import nl.rutgerkok.blocklocker.ProfileFactory;
 import nl.rutgerkok.blocklocker.ProtectionSign;
@@ -10,12 +16,6 @@ import nl.rutgerkok.blocklocker.SignParser;
 import nl.rutgerkok.blocklocker.profile.PlayerProfile;
 import nl.rutgerkok.blocklocker.profile.Profile;
 import nl.rutgerkok.blocklocker.protection.Protection;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 
 /**
  * Updates outdated names on protections.

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionUUIDSetter.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionUUIDSetter.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Optional;
 
 import nl.rutgerkok.blocklocker.BlockLockerPlugin;
 import nl.rutgerkok.blocklocker.ProtectionSign;
@@ -13,8 +13,6 @@ import nl.rutgerkok.blocklocker.impl.converter.UUIDHandler.Result;
 import nl.rutgerkok.blocklocker.profile.PlayerProfile;
 import nl.rutgerkok.blocklocker.profile.Profile;
 import nl.rutgerkok.blocklocker.protection.Protection;
-
-import com.google.common.base.Optional;
 
 class ProtectionUUIDSetter extends UUIDHandler.ResultConsumer {
 
@@ -34,8 +32,7 @@ class ProtectionUUIDSetter extends UUIDHandler.ResultConsumer {
         }
     }
 
-    private void finishFix(Protection protection,
-            Map<String, Result> results) {
+    private void finishFix(Protection protection, Map<String, Result> results) {
 
         SignParser signParser = plugin.getSignParser();
         for (ProtectionSign sign : protection.getSigns()) {
@@ -49,8 +46,7 @@ class ProtectionUUIDSetter extends UUIDHandler.ResultConsumer {
         }
     }
 
-    private Profile replaceProfile(Profile oldProfile,
-            Map<String, Result> results) {
+    private Profile replaceProfile(Profile oldProfile, Map<String, Result> results) {
         if (!(oldProfile instanceof PlayerProfile)) {
             return oldProfile;
         }
@@ -62,7 +58,7 @@ class ProtectionUUIDSetter extends UUIDHandler.ResultConsumer {
         Result result = results.get(name);
         if (result == null) {
             // No lookup :(
-            return plugin.getProfileFactory().fromNameAndUniqueId(name, Optional.<UUID> absent());
+            return plugin.getProfileFactory().fromNameAndUniqueId(name, Optional.empty());
         } else {
             // Valid profile, replace
             return plugin.getProfileFactory().fromNameAndUniqueId(result.getName(), result.getUniqueId());

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionUpdaterImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/converter/ProtectionUpdaterImpl.java
@@ -3,6 +3,7 @@ package nl.rutgerkok.blocklocker.impl.converter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -10,7 +11,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import nl.rutgerkok.blocklocker.BlockLockerPlugin;

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/converter/UUIDHandler.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/converter/UUIDHandler.java
@@ -11,8 +11,10 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -25,8 +27,6 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -40,17 +40,14 @@ final class UUIDHandler {
          * Attempts to find the 16th character of names that were trimmed to 15
          * characters.
          */
-        private static Function<String, String> COMPLETE_NAME = new Function<String, String>() {
-            @Override
-            public String apply(String name) {
-                if (name.length() == MAX_SIGN_LINE_LENGTH) {
-                    List<Player> matches = Bukkit.matchPlayer(name);
-                    if (!matches.isEmpty()) {
-                        return matches.get(0).getName();
-                    }
+        private static Function<String, String> COMPLETE_NAME = name -> {
+        	if (name.length() == MAX_SIGN_LINE_LENGTH) {
+                List<Player> matches = Bukkit.matchPlayer(name);
+                if (!matches.isEmpty()) {
+                    return matches.get(0).getName();
                 }
-                return name;
             }
+            return name;
         };
 
         /**
@@ -58,12 +55,9 @@ final class UUIDHandler {
          * Minecraft's sign limitations) to a {@link Result} that only contains the
          * name, with an absent UUID.
          */
-        private static Function<String, Result> OFFLINE_MODE_LOOKUP = new Function<String, Result>() {
-            @Override
-            public Result apply(String name) {
-                name = COMPLETE_NAME.apply(name);
-                return new Result(name);
-            }
+        private static Function<String, Result> OFFLINE_MODE_LOOKUP = name -> {
+        	name = COMPLETE_NAME.apply(name);
+            return new Result(name);
         };
 
         /**
@@ -73,19 +67,17 @@ final class UUIDHandler {
          * {@code new UUID(0, 0)} so that the plugin doesn't constantly tries to look it
          * up.
          */
-        private static Function<String, Result> ONLINE_MODE_PLACEHOLDERS = new Function<String, Result>() {
-            @Override
-            public Result apply(String name) {
-                if (needsPrefixIfInvalidName(name)) {
-                    // Adding a prefix makes the name look invalid to the player
-                    name = invalidNamePrefixes[0] + name;
-                }
-                return new Result(name, ZERO_UUID);
+        private static Function<String, Result> ONLINE_MODE_PLACEHOLDERS = name -> {
+        	if (needsPrefixIfInvalidName(name)) {
+                // Adding a prefix makes the name look invalid to the player
+                name = invalidNamePrefixes[0] + name;
             }
+            return new Result(name, ZERO_UUID);
         };
     }
 
     private static class MojangWeb {
+    	
         private static final String BULK_UUID_LOOKUP_URL = "https://api.mojang.com/profiles/minecraft";
         private static JSONParser jsonParser = new JSONParser();
         private static final double PROFILES_PER_BULK_REQUEST = 100;
@@ -133,7 +125,7 @@ final class UUIDHandler {
 
         private Result(String name) {
             this.name = name;
-            this.uuid = Optional.absent();
+            this.uuid = Optional.empty();
         }
 
         private Result(String name, UUID uniqueId) {
@@ -175,7 +167,7 @@ final class UUIDHandler {
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + "[name=" + name + ",uuid=" + uuid.orNull() + "]";
+            return getClass().getSimpleName() + "[name=" + name + ",uuid=" + uuid.orElse(null) + "]";
         }
     }
 

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/BlockDestroyListener.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/BlockDestroyListener.java
@@ -2,6 +2,7 @@ package nl.rutgerkok.blocklocker.impl.event;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -25,8 +26,6 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 
-import com.google.common.base.Optional;
-
 import nl.rutgerkok.blocklocker.AttackType;
 import nl.rutgerkok.blocklocker.BlockLockerPlugin;
 import nl.rutgerkok.blocklocker.Permissions;
@@ -44,15 +43,15 @@ public class BlockDestroyListener extends EventListener {
     private Optional<ProtectionSign> asMainSign(Block block) {
         Material material = block.getType();
         if (!Tag.WALL_SIGNS.isTagged(material) && !Tag.STANDING_SIGNS.isTagged(material)) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         Optional<ProtectionSign> protectionSign = plugin.getSignParser().parseSign(block);
         if (!protectionSign.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
         if (!protectionSign.get().getType().isMainSign()) {
-            return Optional.absent();
+            return Optional.empty();
         }
         return protectionSign;
     }
@@ -68,8 +67,7 @@ public class BlockDestroyListener extends EventListener {
     @EventHandler(ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         Block block = event.getBlock();
-        Optional<Protection> protection = plugin.getProtectionFinder()
-                .findProtection(block);
+        Optional<Protection> protection = plugin.getProtectionFinder().findProtection(block);
         if (!protection.isPresent()) {
             return;
         }

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/BlockLockerCommand.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/BlockLockerCommand.java
@@ -3,12 +3,7 @@ package nl.rutgerkok.blocklocker.impl.event;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import nl.rutgerkok.blocklocker.BlockLockerPlugin;
-import nl.rutgerkok.blocklocker.Permissions;
-import nl.rutgerkok.blocklocker.SignType;
-import nl.rutgerkok.blocklocker.Translator.Translation;
-import nl.rutgerkok.blocklocker.protection.Protection;
+import java.util.Optional;
 
 import org.bukkit.block.Sign;
 import org.bukkit.command.Command;
@@ -17,8 +12,13 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+
+import nl.rutgerkok.blocklocker.BlockLockerPlugin;
+import nl.rutgerkok.blocklocker.Permissions;
+import nl.rutgerkok.blocklocker.SignType;
+import nl.rutgerkok.blocklocker.Translator.Translation;
+import nl.rutgerkok.blocklocker.protection.Protection;
 
 public final class BlockLockerCommand implements TabExecutor {
 

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/EventListener.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/EventListener.java
@@ -2,17 +2,16 @@ package nl.rutgerkok.blocklocker.impl.event;
 
 import java.util.Collection;
 import java.util.Date;
-
-import nl.rutgerkok.blocklocker.BlockLockerPlugin;
-import nl.rutgerkok.blocklocker.SearchMode;
-import nl.rutgerkok.blocklocker.profile.Profile;
-import nl.rutgerkok.blocklocker.protection.Protection;
+import java.util.Optional;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.block.Block;
 import org.bukkit.event.Listener;
 
-import com.google.common.base.Optional;
+import nl.rutgerkok.blocklocker.BlockLockerPlugin;
+import nl.rutgerkok.blocklocker.SearchMode;
+import nl.rutgerkok.blocklocker.profile.Profile;
+import nl.rutgerkok.blocklocker.protection.Protection;
 
 abstract class EventListener implements Listener {
 

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/InteractListener.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/InteractListener.java
@@ -1,5 +1,6 @@
 package nl.rutgerkok.blocklocker.impl.event;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.bukkit.Bukkit;
@@ -26,7 +27,6 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import nl.rutgerkok.blocklocker.BlockLockerPlugin;
@@ -144,7 +144,7 @@ public final class InteractListener extends EventListener {
         if (isOfType(offHand, Tag.SIGNS)) {
             return Optional.of(offHand.getType());
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private void handleAllowed(PlayerInteractEvent event, Protection protection, boolean clickedSign,

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/SignChangeListener.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/SignChangeListener.java
@@ -1,13 +1,13 @@
 package nl.rutgerkok.blocklocker.impl.event;
 
+import java.util.Optional;
+
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.SignChangeEvent;
-
-import com.google.common.base.Optional;
 
 import nl.rutgerkok.blocklocker.BlockLockerPlugin;
 import nl.rutgerkok.blocklocker.Permissions;

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/nms/NMSAccessor.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/nms/NMSAccessor.java
@@ -3,14 +3,13 @@ package nl.rutgerkok.blocklocker.impl.nms;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Optional;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Sign;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
-
-import com.google.common.base.Optional;
 
 /**
  * Implementation of methods required by
@@ -234,17 +233,17 @@ public final class NMSAccessor implements ServerSpecific {
     private Optional<String> getSecretData(Object tileEntitySign) {
         Object line = ((Object[]) retrieve(tileEntitySign, TileEntitySign_lines))[0];
         if (line == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         Object chatModifier = call(line, IChatBaseComponent_getChatModifier);
         if (chatModifier == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         Object chatHoverable = call(chatModifier, ChatModifier_getGetHoverEvent);
         if (chatHoverable == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         return Optional.of(chatComponentToString(call(chatHoverable, ChatHoverable_getChatComponent)));
@@ -276,7 +275,7 @@ public final class NMSAccessor implements ServerSpecific {
 
         Object tileEntity = call(nmsWorld, WorldServer_getTileEntity, getBlockPosition(x, y, z));
         if (!TileEntitySign.isInstance(tileEntity)) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         return Optional.of(tileEntity);

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/nms/ServerSpecific.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/nms/ServerSpecific.java
@@ -1,13 +1,13 @@
 package nl.rutgerkok.blocklocker.impl.nms;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.bukkit.World;
 import org.bukkit.block.Sign;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/profile/GroupLeaderProfileImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/profile/GroupLeaderProfileImpl.java
@@ -1,18 +1,18 @@
 package nl.rutgerkok.blocklocker.impl.profile;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
-
-import nl.rutgerkok.blocklocker.group.GroupSystem;
-import nl.rutgerkok.blocklocker.profile.PlayerProfile;
-import nl.rutgerkok.blocklocker.profile.Profile;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.json.simple.JSONObject;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+
+import nl.rutgerkok.blocklocker.group.GroupSystem;
+import nl.rutgerkok.blocklocker.profile.PlayerProfile;
+import nl.rutgerkok.blocklocker.profile.Profile;
 
 /**
  * Implementation of {@link Profile}. Players are considered part of a group

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/profile/GroupProfileImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/profile/GroupProfileImpl.java
@@ -1,19 +1,19 @@
 package nl.rutgerkok.blocklocker.impl.profile;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
-
-import nl.rutgerkok.blocklocker.group.GroupSystem;
-import nl.rutgerkok.blocklocker.profile.GroupProfile;
-import nl.rutgerkok.blocklocker.profile.PlayerProfile;
-import nl.rutgerkok.blocklocker.profile.Profile;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.json.simple.JSONObject;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+
+import nl.rutgerkok.blocklocker.group.GroupSystem;
+import nl.rutgerkok.blocklocker.profile.GroupProfile;
+import nl.rutgerkok.blocklocker.profile.PlayerProfile;
+import nl.rutgerkok.blocklocker.profile.Profile;
 
 /**
  * Implementation of {@link GroupProfile}. Players are considered part of a

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/profile/PlayerProfileImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/profile/PlayerProfileImpl.java
@@ -1,16 +1,15 @@
 package nl.rutgerkok.blocklocker.impl.profile;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
-
-import nl.rutgerkok.blocklocker.profile.PlayerProfile;
-import nl.rutgerkok.blocklocker.profile.Profile;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.json.simple.JSONObject;
 
-import com.google.common.base.Optional;
+import nl.rutgerkok.blocklocker.profile.PlayerProfile;
+import nl.rutgerkok.blocklocker.profile.Profile;
 
 class PlayerProfileImpl implements PlayerProfile {
 
@@ -119,7 +118,7 @@ class PlayerProfileImpl implements PlayerProfile {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[uuid=" + uuid.orNull() + ",name=" + displayName + "]";
+        return getClass().getSimpleName() + "[uuid=" + uuid.orElse(null) + ",name=" + displayName + "]";
     }
 
 }

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/profile/ProfileFactoryImpl.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/profile/ProfileFactoryImpl.java
@@ -2,6 +2,7 @@ package nl.rutgerkok.blocklocker.impl.profile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,7 +10,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 import org.json.simple.JSONObject;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import nl.rutgerkok.blocklocker.ProfileFactory;
@@ -95,7 +95,7 @@ public final class ProfileFactoryImpl implements ProfileFactory {
             }
         }
 
-        return new PlayerProfileImpl(stripped, Optional.<UUID>absent());
+        return new PlayerProfileImpl(stripped, Optional.empty());
     }
 
     @Override
@@ -172,19 +172,19 @@ public final class ProfileFactoryImpl implements ProfileFactory {
             return Optional.of(profile);
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private Optional<UUID> getUniqueId(JSONObject object, String key) {
         Object uuidObject = object.get(key);
         if (!(uuidObject instanceof String)) {
-            return Optional.absent();
+            return Optional.empty();
         }
         try {
             UUID uuid = UUID.fromString((String) uuidObject);
             return Optional.of(uuid);
         } catch (IllegalArgumentException e) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -193,7 +193,7 @@ public final class ProfileFactoryImpl implements ProfileFactory {
         if (type.isInstance(value)) {
             return Optional.of(type.cast(value));
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private int readDigit(char digit) {

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/protection/AbstractProtection.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/protection/AbstractProtection.java
@@ -3,16 +3,16 @@ package nl.rutgerkok.blocklocker.impl.protection;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang.Validate;
+
+import com.google.common.collect.Lists;
 
 import nl.rutgerkok.blocklocker.ProtectionSign;
 import nl.rutgerkok.blocklocker.profile.Profile;
 import nl.rutgerkok.blocklocker.profile.TimerProfile;
 import nl.rutgerkok.blocklocker.protection.Protection;
-
-import org.apache.commons.lang.Validate;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
 
 /**
  * Base class for protection implementations.
@@ -20,9 +20,9 @@ import com.google.common.collect.Lists;
  */
 abstract class AbstractProtection implements Protection {
 
-    private Optional<Collection<Profile>> allAllowed = Optional.absent();
-    private Optional<Profile> owner = Optional.absent();
-    private Optional<Collection<ProtectionSign>> allSigns = Optional.absent();
+    private Optional<Collection<Profile>> allAllowed = Optional.empty();
+    private Optional<Profile> owner = Optional.empty();
+    private Optional<Collection<ProtectionSign>> allSigns = Optional.empty();
 
     /**
      * Constructor for creating the protection with all signs already looked up.
@@ -67,12 +67,12 @@ abstract class AbstractProtection implements Protection {
             if (sign.getType().isMainSign()) {
                 List<Profile> profiles = sign.getProfiles();
                 if (profiles.isEmpty()) {
-                    return Optional.absent();
+                    return Optional.empty();
                 }
                 return Optional.of(profiles.get(0));
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/nl/rutgerkok/blocklocker/profile/PlayerProfile.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/profile/PlayerProfile.java
@@ -1,8 +1,7 @@
 package nl.rutgerkok.blocklocker.profile;
 
+import java.util.Optional;
 import java.util.UUID;
-
-import com.google.common.base.Optional;
 
 public interface PlayerProfile extends Profile {
 

--- a/src/main/java/nl/rutgerkok/blocklocker/protection/Protection.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/protection/Protection.java
@@ -2,11 +2,10 @@ package nl.rutgerkok.blocklocker.protection;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Optional;
 
 import nl.rutgerkok.blocklocker.ProtectionSign;
 import nl.rutgerkok.blocklocker.profile.Profile;
-
-import com.google.common.base.Optional;
 
 /**
  * Represents a generic protection container with its attached signs.

--- a/src/test/java/nl/rutgerkok/blocklocker/impl/profile/TestPlayerProfile.java
+++ b/src/test/java/nl/rutgerkok/blocklocker/impl/profile/TestPlayerProfile.java
@@ -5,12 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.base.Optional;
 
 import nl.rutgerkok.blocklocker.ProfileFactory;
 import nl.rutgerkok.blocklocker.Translator.Translation;


### PR DESCRIPTION
Since Java 8 is around since a while, we can now safely switch to Java 8's Optional class and disregard the guava one.

I also updated the Functions class to use a lambda-powered java.util.function.Function<I,O> implementation.

Fair warning: I am aware that this could potentially break any plugins hooking into BlockLocker.
So I can understand that a warning upfront about this is needed before merging it, otherwise the most commonly used API methods can be upated to also include a deprecated google common Optional method.

P.S. If there is a very good reason why google's Optional class should still be used, then please let me know.