### PR TITLE
Added Villager AttackType (Possibly resolves #24 )

### DIFF
--- a/src/main/java/nl/rutgerkok/blocklocker/AttackType.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/AttackType.java
@@ -8,6 +8,7 @@ import nl.rutgerkok.blocklocker.protection.Protection;
  *
  */
 public enum AttackType {
+	
     CREEPER,
     ENDERMAN,
     FIRE,
@@ -16,5 +17,7 @@ public enum AttackType {
     SAPLING,
     TNT,
     UNKNOWN,
+    VILLAGER,
     ZOMBIE
+    
 }

--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/BlockDestroyListener.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/BlockDestroyListener.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
+import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
@@ -24,6 +25,7 @@ import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.entity.EntityBreakDoorEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 
 import nl.rutgerkok.blocklocker.AttackType;
@@ -129,6 +131,20 @@ public class BlockDestroyListener extends EventListener {
             attackType = AttackType.ZOMBIE;
         } else if (event.getEntity() instanceof Enderman) {
             attackType = AttackType.ENDERMAN;
+        }
+        if (plugin.getChestSettings().allowDestroyBy(attackType)) {
+            return;
+        }
+        if (isProtected(event.getBlock())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onVillagerDoorOpen(EntityInteractEvent event) {
+        AttackType attackType = AttackType.UNKNOWN;
+        if (event.getEntity() instanceof Villager) {
+            attackType = AttackType.VILLAGER;
         }
         if (plugin.getChestSettings().allowDestroyBy(attackType)) {
             return;


### PR DESCRIPTION
Implemented the EntityInteractEvent in BlockDestroyListener.
The implementation is similiar to yours for EntityChangeBlockEvent.

I also added a new AttackType enum constant: VILLAGER,
while Villagers cannot "attack" or "destroy" the block, for now it is a quick and easy implementation that can be moved to it's own config setting at some point.