### PR TITLE
Performance improvements and adding Crafter to the default protection list

### DIFF
--- a/src/main/java/nl/rutgerkok/blocklocker/impl/event/InteractListener.java
+++ b/src/main/java/nl/rutgerkok/blocklocker/impl/event/InteractListener.java
@@ -3,10 +3,7 @@ package nl.rutgerkok.blocklocker.impl.event;
 import java.util.Optional;
 import java.util.Set;
 
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.Material;
-import org.bukkit.Tag;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -25,6 +22,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
@@ -51,6 +49,7 @@ public final class InteractListener extends EventListener {
 
     private static Set<BlockFace> AUTOPLACE_BLOCK_FACES = ImmutableSet.of(BlockFace.NORTH, BlockFace.EAST,
             BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP);
+    private static Set<InventoryType> COMPLEX_SEARCH_INVENTORY = ImmutableSet.of(InventoryType.CHEST);
 
     public InteractListener(BlockLockerPluginImpl plugin) {
         super(plugin);
@@ -131,6 +130,35 @@ public final class InteractListener extends EventListener {
      * @return The block, or null.
      */
     private Block getInventoryBlockOrNull(Inventory inventory) {
+        // Performs a fast Block object fetch for containers with only a single block, avoiding the need to fetch a
+        // BlockState. When creating a BlockState Spigot will create a snapshot, which is a rather slow process.
+
+        if(!COMPLEX_SEARCH_INVENTORY.contains(inventory.getType())) {
+            Location inventoryLoc = inventory.getLocation();
+            if (inventoryLoc != null) {
+                return inventoryLoc.getBlock();
+            }
+            return null; // Custom GUI
+        }
+
+        // Complex search trick for Single Chest
+        // If this is a single chest, we can do same fast fetch just like above
+        if(inventory.getType() == InventoryType.CHEST){
+            Location inventoryLoc = inventory.getLocation();
+            if(inventoryLoc != null){
+                Location invBlockLoc = inventoryLoc.clone();
+                invBlockLoc.setX(inventoryLoc.getBlockX());
+                invBlockLoc.setY(inventoryLoc.getBlockY());
+                invBlockLoc.setZ(inventoryLoc.getBlockZ());
+                // If the two Locations are the same, it means it is not a double chest;
+                // The DoubleChest inventory location is similar like 94.5 64 88.5 (.5)
+                if(inventoryLoc.equals(invBlockLoc)){
+                    return inventoryLoc.getBlock();
+                }
+            }
+        }
+
+        // We've exhausted our means, and now we'll have to use the slowest method just like before.
         InventoryHolder holder = inventory.getHolder();
         if (holder instanceof BlockState) {
             return ((BlockState) holder).getBlock();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,6 +46,7 @@ protectableContainers:
 - chipped_anvil
 - cyan_shulker_box
 - crafting_table
+- crafter
 - damaged_anvil
 - dispenser
 - dropper


### PR DESCRIPTION
## Performance improvements

I've observed BlockLocker-induced performance degradation on our servers.

<img width="1278" alt="7fe95fc656c3cead45fb1b9181778819" src="https://github.com/rutgerkok/BlockLocker/assets/30802565/a6c381d6-8981-457e-92fe-a26ef1129055">

The method `getInventoryBlockOrNull(Inventory)` attempts to acquire the InventoryHolder on each call, and this behavior indirectly creates a new BlockState capture on the block.  

What's worse, however, is that this method is called repeatedly every tick, by the large number of Hoppers running on the server. And Hopper Minecart makes it even worse.

This PR checks the type of the requested Inventory. A fast algorithm is applied to the InventoryType that is not in COMPLEX_SEARCH_INVENTORY list. The unique Block object is returned directly from the Inventory's Location.

Also, for inventory that are in the COMPLEX_SEARCH_INVENTORY list, a quick double-chest check is performed, and if it's not a possible double-chest, we use the same quick algorithm as for the other InventoryTypes, and just return the Block object obtained by Location.

For Double-Chest, they use the same algorithms as in the past, and currently the Bukkit API still doesn't have a good interface to handle them efficiently.

## Crafter

Minor change to add Crafter to the default list.