### PR TITLE
Add missing blocks to default config

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -84,6 +84,8 @@ protectableContainers:
 - minecraft:smoker
 - minecraft:spruce_shelf
 - minecraft:trapped_chest
+- minecraft:warped_shelf
+- minecraft:waxed_copper_chest
 - minecraft:waxed_exposed_copper_chest
 - minecraft:waxed_oxidized_copper_chest
 - minecraft:waxed_weathered_copper_chest


### PR DESCRIPTION
Added missing blocks: `warped_shelf` and `waxed_copper_chest` to the default `config.yml`. I believe these should be in the default config file but were likely accidentally left out.